### PR TITLE
fix: add scorecards permissions and update README for org-level secrets

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -1,4 +1,4 @@
-# Example: Copy this to your repo as .github/workflows/scorecards.yml
+# Calls reusable scorecards workflow from cuioss-organization
 name: Scorecard supply-chain security
 
 on:
@@ -8,7 +8,18 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   analysis:
     uses: cuioss/cuioss-organization/.github/workflows/reusable-scorecards.yml@9ce5ba83776bab80eeffb695f7374e334cf6bd9f # v0.2.0
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+      issues: read
+      pull-requests: read
+      checks: read
     secrets: inherit

--- a/README.adoc
+++ b/README.adoc
@@ -68,25 +68,7 @@ The key must *not* contain spaces. They are used for creating urls as well.
 
 === Credentials
 
-Add the necessary credentials to the project: "Settings" -> "Secrets" -> "Actions", as there are: 
-
-* `GPG_PASSPHRASE` -> Code Signing
-* `GPG_PRIVATE_KEY` -> Code Signing
-* `OSS_SONATYPE_PASSWORD` -> Deploy to maven-central 
-* `OSS_SONATYPE_USERNAME` -> Deploy to maven-central
-* `PAGES_DEPLOY_TOKEN` -> Deploying the result of maven site to https://cuioss.github.io
-* `SONAR_TOKEN` -> Sonar-Cloud
-
-They are picked up in the predefined pipeline-configurations:
-
-* `.github/workflows/maven.yml`
-* `.github/workflows/maven-release.yml`
-
-Ensure that the actions are authorized correctly: Settings > Actions > General > Workflow permissions >  "Read and write permissions" must be selected *not* "Read repository contents permission"
-
-Documentation on how to create a signing key can be found https://github.com/cuioss/cui-parent-pom/blob/master/doc/signing_key.adoc[Documentation at cui-parent-pom] 
-
-A sonar token can be derived from https://sonarcloud.io/account/security
+All secrets (GPG, Sonatype, Sonar, Pages, Release App) are managed at the https://github.com/cuioss/cuioss-organization[cuioss organization level] and inherited automatically via `secrets: inherit` in the reusable workflows. No repo-level secrets need to be configured.
 
 === Further Steps
 


### PR DESCRIPTION
## Summary
- Added workflow-level and job-level permissions to `scorecards.yml` matching the reusable workflow requirements
- Replaced verbose credentials section in `README.adoc` with note that all secrets are managed at org level

## Test plan
- [ ] Verify `build / build (21)`, `build / build (25)`, `build / sonar-build` checks pass
- [ ] After merge, trigger scorecards manually: `gh workflow run scorecards.yml --ref main`
- [ ] Verify scorecards workflow succeeds with the new permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)