### PR TITLE
fix: replace secrets:inherit with explicit secret references

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,4 +14,3 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    secrets: inherit

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,4 +15,9 @@ jobs:
     # This prevents duplicate runs: push handles internal branches, PR handles forks
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-build.yml@9ce5ba83776bab80eeffb695f7374e334cf6bd9f # v0.2.0
-    secrets: inherit
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
+      OSS_SONATYPE_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,4 +16,11 @@ jobs:
   release:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
     uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@9ce5ba83776bab80eeffb695f7374e334cf6bd9f # v0.2.0
-    secrets: inherit
+    secrets:
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+      OSS_SONATYPE_USERNAME: ${{ secrets.OSS_SONATYPE_USERNAME }}
+      OSS_SONATYPE_PASSWORD: ${{ secrets.OSS_SONATYPE_PASSWORD }}
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+      PAGES_DEPLOY_TOKEN: ${{ secrets.PAGES_DEPLOY_TOKEN }}

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -22,4 +22,3 @@ jobs:
       issues: read
       pull-requests: read
       checks: read
-    secrets: inherit


### PR DESCRIPTION
## Summary
- Replace `secrets: inherit` with explicit secret lists to satisfy SonarCloud security hotspot rule `githubactions:S7635` (principle of least privilege)
- `maven.yml`: passes only `SONAR_TOKEN`, `OSS_SONATYPE_USERNAME`, `OSS_SONATYPE_PASSWORD`, `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`
- `release.yml`: passes only `RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`, `OSS_SONATYPE_*`, `GPG_*`, `PAGES_DEPLOY_TOKEN`
- `dependency-review.yml`: removed `secrets: inherit` (workflow uses no secrets)
- `scorecards.yml`: removed `secrets: inherit` (workflow uses no secrets)

## Test plan
- [ ] Verify `build / build (21)`, `build / build (25)`, `build / sonar-build` pass (secrets correctly forwarded)
- [ ] Verify SonarCloud security hotspots are resolved after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)