### PR TITLE
fix: add top-level permissions to maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     # Run on push events, OR on pull_request only if from a fork


### PR DESCRIPTION
## Summary
- Add `permissions: contents: read` to `maven.yml` to resolve OpenSSF Scorecard `TokenPermissionsID` alert

## Test plan
- [ ] `build / build (21)`, `build / build (25)`, `build / sonar-build` pass
- [ ] After merge, scorecard `TokenPermissionsID` alert for `maven.yml:1` resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)