### PR TITLE
fix: add FUNDING.yml for sponsor button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: cuioss


### PR DESCRIPTION
## Summary
- Add `.github/FUNDING.yml` with `github: cuioss` to enable the sponsor button
- Template repositories (`is_template: true`) don't inherit community health files from the org `.github` repo, so this must be added explicitly

## Test plan
- [ ] Verify sponsor button appears on the repository page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)