### PR TITLE
chore: add github-automation config (auto-merge enabled)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -23,3 +23,6 @@ sonar:
 pages:
   reference: cui-java-module-template
   deploy-at-release: true
+github-automation:
+  auto-merge-build-versions: true
+  auto-merge-build-timeout: 240


### PR DESCRIPTION
Adds `github-automation` section to project.yml with auto-merge enabled. Workflow update PRs will be automatically merged when CI passes.