### PR TITLE
chore: remove redundant FUNDING.yml (inherited from org)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,0 @@
-github: cuioss


### PR DESCRIPTION
FUNDING.yml is inherited from the org-level cuioss/.github repo. Repo-level copy is redundant.