### PR TITLE
fix: update release workflow to cuioss-organization v0.2.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ permissions:
 jobs:
   release:
     if: github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch'
-    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@9ce5ba83776bab80eeffb695f7374e334cf6bd9f # v0.2.0
+    permissions:
+      contents: write
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-maven-release.yml@d38bc3643f0d0faa34ece1c2d854cf97f9a0abd4 # v0.2.8
     secrets:
       RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
       RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Update reusable-maven-release.yml SHA reference to v0.2.8 which includes the tag fix (no more duplicate v-prefixed tags).

Also adds job-level `contents: write` permissions to the release job while keeping top-level `contents: read`.