### PR TITLE
chore: add dependabot auto-merge workflow for cuioss dependencies

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,14 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    uses: cuioss/cuioss-organization/.github/workflows/reusable-dependabot-auto-merge.yml@7f9eecb85e04771d0dacfe2b102fd094558eff1d # v0.4.0
+    permissions:
+      contents: write
+      pull-requests: write


### PR DESCRIPTION
## Summary
- Adds thin caller workflow for `reusable-dependabot-auto-merge.yml` (introduced in cuioss-organization v0.4.0)
- Dependabot PRs updating `de.cuioss` dependencies will be automatically squash-merged when CI passes
- Uses the same SHA-pinned reference pattern as other reusable workflows

## Test plan
- [ ] CI passes on this PR (adding a workflow file doesn't affect existing builds)
- [ ] After merge: verify Dependabot PRs for `de.cuioss` deps get auto-merge enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)